### PR TITLE
Make ufdbguard logs readable by the Server Manager

### DIFF
--- a/nethserver-squidguard.spec
+++ b/nethserver-squidguard.spec
@@ -24,6 +24,7 @@ NethServer ufdbGuard (squidGuard) configuration
 %build
 %{makedocs}
 perl createlinks
+mkdir -p root/var/log/ufdbguard
 
 %install
 rm -rf %{buildroot}
@@ -32,6 +33,7 @@ rm -rf %{buildroot}
 --dir /var/squidGuard/blacklists/custom/blacklist 'attr(0755,squid,squid)' \
 --dir /var/squidGuard/blacklists/custom/whitelist 'attr(0755,squid,squid)' \
 --dir /var/squidGuard/blacklists/custom/files 'attr(0755,squid,squid)' \
+--dir /var/log/ufdbguard 'attr(0700,ufdb,ufdb)' \
 --dir /var/squidGuard/blacklists/custom 'attr(0755,squid,squid)'
 
 echo "%doc COPYING" >> %{name}-%{version}-filelist
@@ -44,6 +46,7 @@ echo "%config /etc/squid/blacklists" >> %{name}-%{version}-filelist
 %files -f %{name}-%{version}-filelist
 %defattr(-,root,root)
 %dir %{_nseventsdir}/%{name}-update
+%dir /var/log/ufdbguard
 
 %changelog
 * Tue Jan 24 2017 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.6.2-1

--- a/root/etc/e-smith/templates/etc/ufdbguard/ufdbGuard.conf/10base
+++ b/root/etc/e-smith/templates/etc/ufdbguard/ufdbGuard.conf/10base
@@ -6,7 +6,7 @@
 # # Make sure that you edit the 4 lines that are marked with
 # # 'EDIT THE NEXT LINE...' to adapt this file to your environment.
 #
-logdir "/var/ufdbguard/logs"
+logdir "/var/log/ufdbguard"
 dbhome "/var/squidGuard/blacklists"
 squid-version "3.5"
 analyse-uncategorised-urls off


### PR DESCRIPTION
Create a new directory in var/log called ufdbguard.
Change logdir in ufdbGuard.conf from /var/ufdbguard/logs to /var/log/ufdbguard.