### PR TITLE
Fixed ufdbguard directories in logrotate config

### DIFF
--- a/root/etc/e-smith/templates/etc/logrotate.d/squidGuard/10base
+++ b/root/etc/e-smith/templates/etc/logrotate.d/squidGuard/10base
@@ -1,6 +1,6 @@
-/var/ufdbguard/logs/ufdbgclient.log
-/var/ufdbguard/logs/ufdbguardd.log
-/var/ufdbguard/logs/ufdbsignal.log
+/var/log/ufdbguard/ufdbgclient.log
+/var/log/ufdbguard/ufdbguardd.log
+/var/log/ufdbguard/ufdbsignal.log
 \{
     compress
     notifempty


### PR DESCRIPTION
Changed logrotate directories to make rotation working with new logs position.
NethServer/dev#5255