### PR TITLE
UI improvements

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/ContentFilter/Filters/Modify.php
+++ b/root/usr/share/nethesis/NethServer/Module/ContentFilter/Filters/Modify.php
@@ -119,7 +119,7 @@ class Modify extends \Nethgui\Controller\Table\Modify
 
         $this->setSchema($parameterSchema);
         $this->setDefaultValue('BlockAll', 'disabled');
-        $this->setDefaultValue('BlockIpAccess', 'enabled');
+        $this->setDefaultValue('BlockIpAccess', 'disabled');
 
         parent::initialize();
     }

--- a/root/usr/share/nethesis/NethServer/Module/ContentFilter/Filters/Modify.php
+++ b/root/usr/share/nethesis/NethServer/Module/ContentFilter/Filters/Modify.php
@@ -111,7 +111,6 @@ class Modify extends \Nethgui\Controller\Table\Modify
             array('BlockAll', Validate::SERVICESTATUS,  \Nethgui\Controller\Table\Modify::FIELD),
             array('BlockIpAccess', Validate::SERVICESTATUS, \Nethgui\Controller\Table\Modify::FIELD),
             array('BlockFileTypes', Validate::SERVICESTATUS, \Nethgui\Controller\Table\Modify::FIELD),
-            array('BlockBuiltinRules', Validate::SERVICESTATUS, \Nethgui\Controller\Table\Modify::FIELD),
             array('WhiteList', Validate::SERVICESTATUS, \Nethgui\Controller\Table\Modify::FIELD),
             array('BlackList', Validate::SERVICESTATUS, \Nethgui\Controller\Table\Modify::FIELD),
             array('Categories', $cvalidator, \Nethgui\Controller\Table\Modify::FIELD, 'Categories', ','),
@@ -121,7 +120,6 @@ class Modify extends \Nethgui\Controller\Table\Modify
         $this->setSchema($parameterSchema);
         $this->setDefaultValue('BlockAll', 'disabled');
         $this->setDefaultValue('BlockIpAccess', 'enabled');
-        $this->setDefaultValue('BlockBuiltinRules', 'enabled');
 
         parent::initialize();
     }

--- a/root/usr/share/nethesis/NethServer/Template/ContentFilter/Filters/Modify.php
+++ b/root/usr/share/nethesis/NethServer/Template/ContentFilter/Filters/Modify.php
@@ -17,9 +17,6 @@ echo $view->checkBox('WhiteList', 'enabled')
 echo $view->checkBox('BlockFileTypes', 'enabled')
         ->setAttribute('uncheckedValue', 'disabled');
 
-echo $view->checkBox('BlockBuiltinRules', 'enabled')
-        ->setAttribute('uncheckedValue', 'disabled');
-
 echo $view->selector('BlockAll','disabled');
 echo $view->selector('Categories', $view::SELECTOR_MULTIPLE);
 


### PR DESCRIPTION
- Hide "Block porn sites by regular expressions on URL" option which causes many false-positive.
  Current installation will not be modified. 
- Disable by default "Block access to web sites using ip address" option to avoid unexpected problems if Squid is configured in SSL transparent mode
- Upgrade to ufdbGuard-1.33.4-