### PR TITLE
Avoid double ufdb reload

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-squidguard-update-custom-list
+++ b/root/etc/e-smith/events/actions/nethserver-squidguard-update-custom-list
@@ -62,6 +62,5 @@ exit 0 if ($event eq 'cron');
 
 system("/usr/sbin/ufdbConvertDB /var/squidGuard/blacklists/custom/ >/dev/null 2>&1");
 system("chown -R squid:squid /var/squidGuard/blacklists/custom/");
-system('/usr/sbin/ufdbsignal -C "sighup ufdbguardd" >/dev/null 2>&1');
 
 exit 0

--- a/root/etc/e-smith/events/actions/nethserver-squidguard-update-custom-list
+++ b/root/etc/e-smith/events/actions/nethserver-squidguard-update-custom-list
@@ -52,13 +52,7 @@ system("/sbin/e-smith/expand-template /var/squidGuard/blacklists/custom/whitelis
 system("/sbin/e-smith/expand-template /var/squidGuard/blacklists/custom/files/expressions");
 system("/sbin/e-smith/expand-template /var/squidGuard/blacklists/custom/blacklist/domains");
 system("/sbin/e-smith/expand-template /var/squidGuard/blacklists/custom/blacklist/urls");
-
-
-system("chown -R squid:squid /var/squidGuard/blacklists/custom/");
 system("/sbin/e-smith/expand-template /etc/ufdbguard/ufdbGuard.conf");
-
-# If executed from cron, do not apply configuration
-exit 0 if ($event eq 'cron');
 
 system("/usr/sbin/ufdbConvertDB /var/squidGuard/blacklists/custom/ >/dev/null 2>&1");
 system("chown -R squid:squid /var/squidGuard/blacklists/custom/");


### PR DESCRIPTION
This change should prevent a race condition during the save event.

NethServer/dev#5777