### PR TITLE
systemd: replace EPEL unit

### DIFF
--- a/root/etc/systemd/system/ufdbGuard.service
+++ b/root/etc/systemd/system/ufdbGuard.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=ufdbGuard URL filter
+After=syslog.target network.target
+
+[Service]
+Type=forking
+EnvironmentFile=-/etc/sysconfig/ufdbguard
+ExecStart=/usr/sbin/ufdbguardd -U ufdb
+ExecReload=/bin/kill -HUP ${MAINPID}
+
+[Install]
+WantedBy=multi-user.target

--- a/root/etc/systemd/system/ufdbGuard.service.d/nethserver.conf
+++ b/root/etc/systemd/system/ufdbGuard.service.d/nethserver.conf
@@ -1,2 +1,0 @@
-[Service]
-ExecReload=/bin/kill -HUP ${MAINPID}


### PR DESCRIPTION
If the server is started with ufdb user directly from systemd,
ufdb will run execuserlist script with ufdb permission.
To retrieve the list of the user the script must be executed with root
permissions, while the daemon keeps running with ufdb user.

NethServer/dev#6262