### PR TITLE
systemd unit: restart ufdbGuard on failure

### DIFF
--- a/root/etc/systemd/system/ufdbGuard.service
+++ b/root/etc/systemd/system/ufdbGuard.service
@@ -5,8 +5,10 @@ After=syslog.target network.target
 [Service]
 Type=forking
 EnvironmentFile=-/etc/sysconfig/ufdbguard
+ExecStartPre=-/usr/bin/sh -c '/usr/bin/rm -f /tmp/ufdbguardd-*'
 ExecStart=/usr/sbin/ufdbguardd -U ufdb
 ExecReload=/bin/kill -HUP ${MAINPID}
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Also make sure that socket has been deleted before start to avoid errors
like:
```
cannot bind daemon socket: Success (protocol=UNIX)  *****
check for and kill old daemon processes
and remove UNIX socket file "/tmp/ufdbguardd-03977"
```

NethServer/dev#6323