### PR TITLE
cron: suppress wget output

### DIFF
--- a/root/etc/cron.daily/update-squidguard-blacklists
+++ b/root/etc/cron.daily/update-squidguard-blacklists
@@ -37,7 +37,7 @@ function download_extract {
     else
         verbose="--quiet"
     fi
-    wget $verbose -O $BLFILE $1
+    wget $verbose -O $BLFILE $1 2>/dev/null
     if [ $? -gt 0 ] && [ ! -s $BLFILE ] ; then
         restore
     else


### PR DESCRIPTION
Do not create output if wget is trying to download an empty URL.
Avoid daily mails containing:

  wget: missing URL
  Usage: wget [OPTION]... [URL]...

  Try `wget --help' for more options.

NethServer/dev#6624