### PR TITLE
toulouse: change mirror URL

### DIFF
--- a/root/etc/e-smith/templates/etc/squid/blacklists/10base
+++ b/root/etc/e-smith/templates/etc/squid/blacklists/10base
@@ -4,7 +4,7 @@
     my @lists = split(/,/,$l);
 
     if( 'toulouse' ~~ @lists ) {
-        $OUT .= "ftp://ftp.ut-capitole.fr/pub/reseau/cache/squidguard_contrib/blacklists.tar.gz\n";
+        $OUT .= "https://github.com/NethServer/toulouse-bl-mirror/raw/main/blacklists.tar.gz\n";
     }
     if( 'custom' ~~ @lists ) {
         my $custom = $squidguard{'CustomListURL'} || '';


### PR DESCRIPTION
Sometime upstream mirror fails.
We can use NethServer mirror updated by nethbot:
https://github.com/NethServer/toulouse-bl-mirror